### PR TITLE
Modif pour compatibilité php 7.3 (Buster)

### DIFF
--- a/desktop/php/sigri_linky.php
+++ b/desktop/php/sigri_linky.php
@@ -62,7 +62,7 @@
 						<select id="sel_object" class="eqLogicAttr form-control" data-l1key="object_id">
 							<option value="">{{Aucun}}</option>
 							<?php
-								foreach (object::all() as $object) {
+								foreach (jeeObject::all() as $object) {
 									echo '<option value="' . $object->getId() . '">' . $object->getName() . '</option>';
 								}
 							?>


### PR DESCRIPTION
La classe object n'est plus définie dans php 7.3
Il faut utiliser à la place jeeObject